### PR TITLE
Migrar CMS a stack PHP con frontend React

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.gitignore
+README.md
+LICENSE
+ContextDevelop.md
+docker-compose.yml
+backend/data/cms.json

--- a/ContextDevelop.md
+++ b/ContextDevelop.md
@@ -1,0 +1,10 @@
+# Contexto de Desarrollo
+
+Este documento detalla las funcionalidades mínimas necesarias para considerar el CMS operativo:
+
+- Alta, baja y modificación de piezas de PNT incluyendo guion, formato y duración.
+- Organización de PNTs dentro de "tiempos" y agrupación de tiempos dentro de carpetas programadas.
+- Asociación de fechas de emisión a cada carpeta para planificar la salida al aire.
+- Posibilidad de agregar/quitar PNTs dentro de un tiempo y tiempos dentro de una carpeta de manera simple.
+- Generación de resúmenes y agendas diarias para conocer rápidamente qué piezas se emiten.
+- Persistencia local de toda la información para no perder los datos al reiniciar la aplicación.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,84 @@
-# FutbolFolder
-Creacion de un CMS para la carga y lectura de PNT para emisiones de RADIO y TV
+# FutbolFolder CMS
+
+Plataforma ligera para gestionar piezas publicitarias no tradicionales (PNT), organizarlas en tiempos de emisión y planificar carpetas diarias listas para salir al aire. La aplicación se divide en un **backend PHP** expuesto vía API REST y un **frontend HTML5 + React** que consume dichos servicios.
+
+## Arquitectura
+
+- **Backend**: PHP 8+ sin dependencias externas. Expone endpoints RESTful para CRUD de PNTs, tiempos y carpetas; permite asociar entidades, generar resúmenes y consultar agendas diarias. La persistencia se realiza sobre un archivo JSON local (`backend/data/cms.json`).
+- **Frontend**: interfaz React (via CDN) que utiliza HTML5, CSS moderno y JavaScript modular. Ofrece formularios guiados para altas y asignaciones, dashboards con tarjetas para visualizar la programación y paneles de resumen y agenda.
+- **Comunicación**: ambos módulos se comunican mediante JSON. Se incluyen cabeceras CORS para que el frontend pueda ejecutarse en un puerto diferente al backend durante el desarrollo.
+
+## Funcionalidades clave
+
+- Alta, baja y modificación de PNTs con título, guion, formato, marca, duración y notas.
+- Creación de tiempos de emisión y asignación/quita de PNTs dentro de cada tiempo.
+- Programación de carpetas con fecha de salida al aire, observaciones y asociación de tiempos.
+- Reportes automáticos: resumen general (duraciones acumuladas) y agenda diaria filtrada por fecha.
+- Persistencia local robusta: toda operación actualiza el archivo JSON evitando pérdida de datos.
+
+## Puesta en marcha
+
+### 1. Backend PHP
+
+```bash
+cd backend
+php -S localhost:8000 index.php
+```
+
+Esto inicia la API REST en `http://localhost:8000/api`.
+
+### 2. Frontend React
+
+En otra terminal:
+
+```bash
+cd frontend
+php -S localhost:5173
+```
+
+Luego abre `http://localhost:5173` en tu navegador. El frontend apunta por defecto al backend en `http://localhost:8000/api`. Si necesitas cambiar el host o puerto puedes definir `window.APP_CONFIG = { apiUrl: 'http://otro-host:puerto/api' };` antes de cargar `app.js`.
+
+## Endpoints principales
+
+| Método | Ruta                                   | Descripción |
+| ------ | -------------------------------------- | ----------- |
+| GET    | `/api/pnts`                            | Lista todos los PNT registrados. |
+| POST   | `/api/pnts`                            | Crea un nuevo PNT. |
+| GET    | `/api/pnts/{id}`                       | Obtiene un PNT específico. |
+| PUT    | `/api/pnts/{id}`                       | Actualiza un PNT existente. |
+| DELETE | `/api/pnts/{id}`                       | Elimina un PNT y lo desasocia de los tiempos. |
+| GET    | `/api/tiempos`                         | Lista los tiempos de emisión. |
+| POST   | `/api/tiempos`                         | Crea un tiempo nuevo. |
+| POST   | `/api/tiempos/{id}/pnts`               | Asocia un PNT a un tiempo. |
+| DELETE | `/api/tiempos/{id}/pnts/{pntId}`       | Elimina la asociación del PNT dentro del tiempo. |
+| GET    | `/api/carpetas`                        | Lista las carpetas programadas. |
+| POST   | `/api/carpetas`                        | Crea una carpeta con fecha de emisión. |
+| POST   | `/api/carpetas/{id}/tiempos`           | Vincula un tiempo a la carpeta. |
+| DELETE | `/api/carpetas/{id}/tiempos/{tiempo}`  | Quita el tiempo de la carpeta. |
+| GET    | `/api/report/resumen`                  | Devuelve duraciones acumuladas por carpeta y tiempo. |
+| GET    | `/api/report/agenda?date=YYYY-MM-DD`   | Agenda diaria filtrada por fecha de emisión. |
+
+Todas las rutas aceptan/retornan JSON. Ante validaciones fallidas se responde con código 400 y un mensaje descriptivo.
+
+## Persistencia de datos
+
+El archivo `backend/data/cms.json` se genera automáticamente al iniciar la API. Puedes versionarlo o respaldarlo para conservar la programación entre despliegues.
+
+## Desarrollo y pruebas
+
+- Lint rápido del backend:
+
+  ```bash
+  php -l backend/index.php
+  php -l backend/lib/CmsService.php
+  php -l backend/lib/Storage.php
+  ```
+
+- Puedes escribir pruebas end-to-end con herramientas como [Pest](https://pestphp.com/) o [PHPUnit](https://phpunit.de/); la estructura actual facilita su incorporación en `backend/tests/`.
+
+## Próximos pasos sugeridos
+
+- Incorporar autenticación por roles para productores, comerciales y clientes.
+- Añadir exportaciones en PDF/Excel desde el backend para compartir la programación.
+- Implementar filtros avanzados en el frontend (por marca, duración, formato, etc.).
+- Desplegar en un hosting PHP y servir el frontend con un CDN o un servidor estático dedicado.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,22 @@ Plataforma ligera para gestionar piezas publicitarias no tradicionales (PNT), or
 
 ## Puesta en marcha
 
-### 1. Backend PHP
+### Opción A: Docker (recomendada)
+
+1. Asegúrate de tener [Docker](https://docs.docker.com/get-docker/) y [Docker Compose](https://docs.docker.com/compose/install/) instalados.
+2. Desde la raíz del repositorio ejecuta:
+
+   ```bash
+   docker compose up --build
+   ```
+
+3. Accede al frontend en `http://localhost:3000`. La interfaz consumirá automáticamente la API publicada en `http://localhost:8000/api`.
+
+Los datos del CMS se almacenan en un volumen nombrado (`backend-data`), por lo que se preservan entre reinicios de contenedores.
+
+### Opción B: ejecución manual
+
+#### 1. Backend PHP
 
 ```bash
 cd backend
@@ -27,7 +42,7 @@ php -S localhost:8000 index.php
 
 Esto inicia la API REST en `http://localhost:8000/api`.
 
-### 2. Frontend React
+#### 2. Frontend React
 
 En otra terminal:
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,11 @@
+FROM php:8.2-apache
+
+WORKDIR /var/www/html
+
+COPY backend/ /var/www/html/
+
+RUN chown -R www-data:www-data /var/www/html/data
+
+EXPOSE 80
+
+CMD ["apache2-foreground"]

--- a/backend/data/.gitignore
+++ b/backend/data/.gitignore
@@ -1,0 +1,1 @@
+cms.json

--- a/backend/index.php
+++ b/backend/index.php
@@ -1,0 +1,245 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/lib/CmsService.php';
+require_once __DIR__ . '/lib/Storage.php';
+
+$storage = new Storage(__DIR__ . '/data/cms.json');
+$service = new CmsService($storage);
+
+header('Content-Type: application/json; charset=utf-8');
+header('Access-Control-Allow-Origin: *');
+header('Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS');
+header('Access-Control-Allow-Headers: Content-Type');
+
+if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+    http_response_code(204);
+    exit;
+}
+
+$path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH) ?: '/';
+$segments = array_values(array_filter(explode('/', trim($path, '/'))));
+
+function readJsonBody(): array
+{
+    $contents = file_get_contents('php://input');
+    if ($contents === false || trim($contents) === '') {
+        return [];
+    }
+
+    $data = json_decode($contents, true);
+    if ($data === null && json_last_error() !== JSON_ERROR_NONE) {
+        throw new InvalidArgumentException('JSON inválido: ' . json_last_error_msg());
+    }
+
+    return $data ?? [];
+}
+
+function respond(int $status, $payload = null): void
+{
+    http_response_code($status);
+    if ($payload !== null) {
+        echo json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT);
+    }
+}
+
+try {
+    if (count($segments) === 0 || $segments[0] !== 'api') {
+        respond(200, [
+            'name' => 'FutbolFolder CMS API',
+            'version' => '2.0.0',
+            'endpoints' => [
+                '/api/pnts',
+                '/api/tiempos',
+                '/api/carpetas',
+                '/api/report/resumen',
+                '/api/report/agenda?date=YYYY-MM-DD',
+            ],
+        ]);
+        return;
+    }
+
+    $method = $_SERVER['REQUEST_METHOD'];
+
+    if ($segments[1] ?? null) {
+        switch ($segments[1]) {
+            case 'pnts':
+                if ($method === 'GET' && count($segments) === 2) {
+                    respond(200, $service->listPnts());
+                    return;
+                }
+
+                if ($method === 'POST' && count($segments) === 2) {
+                    $payload = readJsonBody();
+                    respond(201, $service->createPnt($payload));
+                    return;
+                }
+
+                if (isset($segments[2])) {
+                    $identifier = $segments[2];
+
+                    if ($method === 'GET') {
+                        $pnt = $service->getPnt($identifier);
+                        if ($pnt === null) {
+                            respond(404, ['error' => 'PNT inexistente']);
+                        } else {
+                            respond(200, $pnt);
+                        }
+                        return;
+                    }
+
+                    if ($method === 'PUT') {
+                        $payload = readJsonBody();
+                        respond(200, $service->updatePnt($identifier, $payload));
+                        return;
+                    }
+
+                    if ($method === 'DELETE') {
+                        $service->deletePnt($identifier);
+                        respond(204);
+                        return;
+                    }
+                }
+                break;
+
+            case 'tiempos':
+                if ($method === 'GET' && count($segments) === 2) {
+                    respond(200, $service->listTiempos());
+                    return;
+                }
+
+                if ($method === 'POST' && count($segments) === 2) {
+                    $payload = readJsonBody();
+                    respond(201, $service->createTiempo($payload));
+                    return;
+                }
+
+                if (isset($segments[2])) {
+                    $identifier = $segments[2];
+
+                    if ($method === 'GET') {
+                        $tiempo = $service->getTiempo($identifier);
+                        if ($tiempo === null) {
+                            respond(404, ['error' => 'Tiempo inexistente']);
+                        } else {
+                            respond(200, $tiempo);
+                        }
+                        return;
+                    }
+
+                    if ($method === 'PUT') {
+                        $payload = readJsonBody();
+                        respond(200, $service->updateTiempo($identifier, $payload));
+                        return;
+                    }
+
+                    if ($method === 'DELETE') {
+                        $service->deleteTiempo($identifier);
+                        respond(204);
+                        return;
+                    }
+
+                    if (isset($segments[3]) && $segments[3] === 'pnts') {
+                        if ($method === 'POST') {
+                            $payload = readJsonBody();
+                            $pntId = $payload['pnt_id'] ?? null;
+                            if ($pntId === null) {
+                                throw new InvalidArgumentException('Se requiere pnt_id');
+                            }
+                            respond(200, $service->addPntToTiempo($identifier, (string) $pntId));
+                            return;
+                        }
+
+                        if ($method === 'DELETE' && isset($segments[4])) {
+                            respond(200, $service->removePntFromTiempo($identifier, $segments[4]));
+                            return;
+                        }
+                    }
+                }
+                break;
+
+            case 'carpetas':
+                if ($method === 'GET' && count($segments) === 2) {
+                    respond(200, $service->listCarpetas());
+                    return;
+                }
+
+                if ($method === 'POST' && count($segments) === 2) {
+                    $payload = readJsonBody();
+                    respond(201, $service->createCarpeta($payload));
+                    return;
+                }
+
+                if (isset($segments[2])) {
+                    $identifier = $segments[2];
+
+                    if ($method === 'GET') {
+                        $carpeta = $service->getCarpeta($identifier);
+                        if ($carpeta === null) {
+                            respond(404, ['error' => 'Carpeta inexistente']);
+                        } else {
+                            respond(200, $carpeta);
+                        }
+                        return;
+                    }
+
+                    if ($method === 'PUT') {
+                        $payload = readJsonBody();
+                        respond(200, $service->updateCarpeta($identifier, $payload));
+                        return;
+                    }
+
+                    if ($method === 'DELETE') {
+                        $service->deleteCarpeta($identifier);
+                        respond(204);
+                        return;
+                    }
+
+                    if (isset($segments[3]) && $segments[3] === 'tiempos') {
+                        if ($method === 'POST') {
+                            $payload = readJsonBody();
+                            $tiempoId = $payload['tiempo_id'] ?? null;
+                            if ($tiempoId === null) {
+                                throw new InvalidArgumentException('Se requiere tiempo_id');
+                            }
+                            respond(200, $service->addTiempoToCarpeta($identifier, (string) $tiempoId));
+                            return;
+                        }
+
+                        if ($method === 'DELETE' && isset($segments[4])) {
+                            respond(200, $service->removeTiempoFromCarpeta($identifier, $segments[4]));
+                            return;
+                        }
+                    }
+                }
+                break;
+
+            case 'report':
+                if ($method === 'GET' && isset($segments[2])) {
+                    if ($segments[2] === 'resumen') {
+                        respond(200, $service->resumenGeneral());
+                        return;
+                    }
+
+                    if ($segments[2] === 'agenda') {
+                        $date = $_GET['date'] ?? null;
+                        if ($date === null) {
+                            throw new InvalidArgumentException('Parámetro date obligatorio');
+                        }
+                        respond(200, $service->agendaPorFecha((string) $date));
+                        return;
+                    }
+                }
+                break;
+        }
+    }
+
+    respond(404, ['error' => 'Ruta no encontrada']);
+} catch (InvalidArgumentException $exception) {
+    respond(400, ['error' => $exception->getMessage()]);
+} catch (RuntimeException $exception) {
+    respond(500, ['error' => $exception->getMessage()]);
+} catch (Throwable $exception) {
+    respond(500, ['error' => 'Error inesperado', 'detalle' => $exception->getMessage()]);
+}

--- a/backend/lib/CmsService.php
+++ b/backend/lib/CmsService.php
@@ -1,0 +1,442 @@
+<?php
+
+require_once __DIR__ . '/Storage.php';
+
+class CmsService
+{
+    private Storage $storage;
+    private array $state;
+
+    public function __construct(Storage $storage)
+    {
+        $this->storage = $storage;
+        $this->state = $storage->load();
+    }
+
+    private function persist(): void
+    {
+        $this->storage->save($this->state);
+    }
+
+    private function ensureIdentifier(string $prefix, ?string $identifier): string
+    {
+        if ($identifier === null || trim($identifier) === '') {
+            return uniqid($prefix, true);
+        }
+
+        return (string) $identifier;
+    }
+
+    public function listPnts(): array
+    {
+        return array_values($this->state['pnts']);
+    }
+
+    public function getPnt(string $identifier): ?array
+    {
+        return $this->state['pnts'][$identifier] ?? null;
+    }
+
+    public function createPnt(array $payload): array
+    {
+        $identifier = $this->ensureIdentifier('pnt_', $payload['identifier'] ?? null);
+        if (isset($this->state['pnts'][$identifier])) {
+            throw new InvalidArgumentException('Ya existe un PNT con ese identificador.');
+        }
+
+        $record = [
+            'identifier' => $identifier,
+            'titulo' => trim($payload['titulo'] ?? ''),
+            'guion' => trim($payload['guion'] ?? ''),
+            'duracion_segundos' => (int) ($payload['duracion_segundos'] ?? 0),
+            'formato' => trim($payload['formato'] ?? ''),
+            'marca' => trim($payload['marca'] ?? ''),
+            'notas' => trim($payload['notas'] ?? ''),
+        ];
+
+        if ($record['titulo'] === '' || $record['guion'] === '') {
+            throw new InvalidArgumentException('El título y el guion son obligatorios.');
+        }
+
+        $this->state['pnts'][$identifier] = $record;
+        $this->persist();
+
+        return $record;
+    }
+
+    public function updatePnt(string $identifier, array $payload): array
+    {
+        if (!isset($this->state['pnts'][$identifier])) {
+            throw new InvalidArgumentException('PNT inexistente.');
+        }
+
+        $record = $this->state['pnts'][$identifier];
+        $record['titulo'] = trim($payload['titulo'] ?? $record['titulo']);
+        $record['guion'] = trim($payload['guion'] ?? $record['guion']);
+        $record['duracion_segundos'] = (int) ($payload['duracion_segundos'] ?? $record['duracion_segundos']);
+        $record['formato'] = trim($payload['formato'] ?? $record['formato']);
+        $record['marca'] = trim($payload['marca'] ?? $record['marca']);
+        $record['notas'] = trim($payload['notas'] ?? $record['notas']);
+
+        if ($record['titulo'] === '' || $record['guion'] === '') {
+            throw new InvalidArgumentException('El título y el guion son obligatorios.');
+        }
+
+        $this->state['pnts'][$identifier] = $record;
+        $this->persist();
+
+        return $record;
+    }
+
+    public function deletePnt(string $identifier): void
+    {
+        if (!isset($this->state['pnts'][$identifier])) {
+            throw new InvalidArgumentException('PNT inexistente.');
+        }
+
+        unset($this->state['pnts'][$identifier]);
+
+        foreach ($this->state['tiempos'] as &$tiempo) {
+            $tiempo['pnt_ids'] = array_values(array_filter(
+                $tiempo['pnt_ids'],
+                fn ($id) => $id !== $identifier
+            ));
+        }
+
+        $this->persist();
+    }
+
+    public function listTiempos(): array
+    {
+        return array_values($this->state['tiempos']);
+    }
+
+    public function getTiempo(string $identifier): ?array
+    {
+        return $this->state['tiempos'][$identifier] ?? null;
+    }
+
+    public function createTiempo(array $payload): array
+    {
+        $identifier = $this->ensureIdentifier('tiempo_', $payload['identifier'] ?? null);
+        if (isset($this->state['tiempos'][$identifier])) {
+            throw new InvalidArgumentException('Ya existe un tiempo con ese identificador.');
+        }
+
+        $record = [
+            'identifier' => $identifier,
+            'nombre' => trim($payload['nombre'] ?? ''),
+            'duracion_total' => (int) ($payload['duracion_total'] ?? 0),
+            'pnt_ids' => array_values(array_unique($payload['pnt_ids'] ?? [])),
+        ];
+
+        if ($record['nombre'] === '') {
+            throw new InvalidArgumentException('El nombre del tiempo es obligatorio.');
+        }
+
+        $this->validatePntIds($record['pnt_ids']);
+
+        $this->state['tiempos'][$identifier] = $record;
+        $this->persist();
+
+        return $record;
+    }
+
+    public function updateTiempo(string $identifier, array $payload): array
+    {
+        if (!isset($this->state['tiempos'][$identifier])) {
+            throw new InvalidArgumentException('Tiempo inexistente.');
+        }
+
+        $record = $this->state['tiempos'][$identifier];
+        $record['nombre'] = trim($payload['nombre'] ?? $record['nombre']);
+        $record['duracion_total'] = (int) ($payload['duracion_total'] ?? $record['duracion_total']);
+
+        if (isset($payload['pnt_ids'])) {
+            $pntIds = array_values(array_unique($payload['pnt_ids']));
+            $this->validatePntIds($pntIds);
+            $record['pnt_ids'] = $pntIds;
+        }
+
+        if ($record['nombre'] === '') {
+            throw new InvalidArgumentException('El nombre del tiempo es obligatorio.');
+        }
+
+        $this->state['tiempos'][$identifier] = $record;
+        $this->persist();
+
+        return $record;
+    }
+
+    public function deleteTiempo(string $identifier): void
+    {
+        if (!isset($this->state['tiempos'][$identifier])) {
+            throw new InvalidArgumentException('Tiempo inexistente.');
+        }
+
+        unset($this->state['tiempos'][$identifier]);
+
+        foreach ($this->state['carpetas'] as &$carpeta) {
+            $carpeta['tiempo_ids'] = array_values(array_filter(
+                $carpeta['tiempo_ids'],
+                fn ($id) => $id !== $identifier
+            ));
+        }
+
+        $this->persist();
+    }
+
+    public function addPntToTiempo(string $tiempoId, string $pntId): array
+    {
+        $tiempo = $this->state['tiempos'][$tiempoId] ?? null;
+        if ($tiempo === null) {
+            throw new InvalidArgumentException('Tiempo inexistente.');
+        }
+
+        if (!isset($this->state['pnts'][$pntId])) {
+            throw new InvalidArgumentException('PNT inexistente.');
+        }
+
+        if (!in_array($pntId, $tiempo['pnt_ids'], true)) {
+            $tiempo['pnt_ids'][] = $pntId;
+        }
+
+        $this->state['tiempos'][$tiempoId] = $tiempo;
+        $this->persist();
+
+        return $tiempo;
+    }
+
+    public function removePntFromTiempo(string $tiempoId, string $pntId): array
+    {
+        $tiempo = $this->state['tiempos'][$tiempoId] ?? null;
+        if ($tiempo === null) {
+            throw new InvalidArgumentException('Tiempo inexistente.');
+        }
+
+        $tiempo['pnt_ids'] = array_values(array_filter(
+            $tiempo['pnt_ids'],
+            fn ($id) => $id !== $pntId
+        ));
+
+        $this->state['tiempos'][$tiempoId] = $tiempo;
+        $this->persist();
+
+        return $tiempo;
+    }
+
+    public function listCarpetas(): array
+    {
+        return array_values($this->state['carpetas']);
+    }
+
+    public function getCarpeta(string $identifier): ?array
+    {
+        return $this->state['carpetas'][$identifier] ?? null;
+    }
+
+    public function createCarpeta(array $payload): array
+    {
+        $identifier = $this->ensureIdentifier('carpeta_', $payload['identifier'] ?? null);
+        if (isset($this->state['carpetas'][$identifier])) {
+            throw new InvalidArgumentException('Ya existe una carpeta con ese identificador.');
+        }
+
+        $fecha = $this->parseDate($payload['fecha_emision'] ?? null);
+
+        $record = [
+            'identifier' => $identifier,
+            'nombre' => trim($payload['nombre'] ?? ''),
+            'fecha_emision' => $fecha->format('Y-m-d'),
+            'tiempo_ids' => array_values(array_unique($payload['tiempo_ids'] ?? [])),
+            'observaciones' => trim($payload['observaciones'] ?? ''),
+        ];
+
+        if ($record['nombre'] === '') {
+            throw new InvalidArgumentException('El nombre de la carpeta es obligatorio.');
+        }
+
+        $this->validateTiempoIds($record['tiempo_ids']);
+
+        $this->state['carpetas'][$identifier] = $record;
+        $this->persist();
+
+        return $record;
+    }
+
+    public function updateCarpeta(string $identifier, array $payload): array
+    {
+        if (!isset($this->state['carpetas'][$identifier])) {
+            throw new InvalidArgumentException('Carpeta inexistente.');
+        }
+
+        $record = $this->state['carpetas'][$identifier];
+        $record['nombre'] = trim($payload['nombre'] ?? $record['nombre']);
+        if (isset($payload['fecha_emision'])) {
+            $fecha = $this->parseDate($payload['fecha_emision']);
+            $record['fecha_emision'] = $fecha->format('Y-m-d');
+        }
+
+        if (isset($payload['tiempo_ids'])) {
+            $tiempoIds = array_values(array_unique($payload['tiempo_ids']));
+            $this->validateTiempoIds($tiempoIds);
+            $record['tiempo_ids'] = $tiempoIds;
+        }
+
+        $record['observaciones'] = trim($payload['observaciones'] ?? $record['observaciones']);
+
+        if ($record['nombre'] === '') {
+            throw new InvalidArgumentException('El nombre de la carpeta es obligatorio.');
+        }
+
+        $this->state['carpetas'][$identifier] = $record;
+        $this->persist();
+
+        return $record;
+    }
+
+    public function deleteCarpeta(string $identifier): void
+    {
+        if (!isset($this->state['carpetas'][$identifier])) {
+            throw new InvalidArgumentException('Carpeta inexistente.');
+        }
+
+        unset($this->state['carpetas'][$identifier]);
+        $this->persist();
+    }
+
+    public function addTiempoToCarpeta(string $carpetaId, string $tiempoId): array
+    {
+        $carpeta = $this->state['carpetas'][$carpetaId] ?? null;
+        if ($carpeta === null) {
+            throw new InvalidArgumentException('Carpeta inexistente.');
+        }
+
+        if (!isset($this->state['tiempos'][$tiempoId])) {
+            throw new InvalidArgumentException('Tiempo inexistente.');
+        }
+
+        if (!in_array($tiempoId, $carpeta['tiempo_ids'], true)) {
+            $carpeta['tiempo_ids'][] = $tiempoId;
+        }
+
+        $this->state['carpetas'][$carpetaId] = $carpeta;
+        $this->persist();
+
+        return $carpeta;
+    }
+
+    public function removeTiempoFromCarpeta(string $carpetaId, string $tiempoId): array
+    {
+        $carpeta = $this->state['carpetas'][$carpetaId] ?? null;
+        if ($carpeta === null) {
+            throw new InvalidArgumentException('Carpeta inexistente.');
+        }
+
+        $carpeta['tiempo_ids'] = array_values(array_filter(
+            $carpeta['tiempo_ids'],
+            fn ($id) => $id !== $tiempoId
+        ));
+
+        $this->state['carpetas'][$carpetaId] = $carpeta;
+        $this->persist();
+
+        return $carpeta;
+    }
+
+    public function resumenGeneral(): array
+    {
+        $result = [];
+        foreach ($this->state['carpetas'] as $carpeta) {
+            $totalDuracion = 0;
+            $tiempos = [];
+            foreach ($carpeta['tiempo_ids'] as $tiempoId) {
+                $tiempo = $this->state['tiempos'][$tiempoId] ?? null;
+                if ($tiempo === null) {
+                    continue;
+                }
+                $duracionTiempo = $tiempo['duracion_total'];
+                $pnts = [];
+                foreach ($tiempo['pnt_ids'] as $pntId) {
+                    $pnt = $this->state['pnts'][$pntId] ?? null;
+                    if ($pnt === null) {
+                        continue;
+                    }
+                    $duracionTiempo += $pnt['duracion_segundos'];
+                    $pnts[] = $pnt;
+                }
+                $totalDuracion += $duracionTiempo;
+                $tiempos[] = [
+                    'tiempo' => $tiempo,
+                    'pnts' => $pnts,
+                    'duracion_total_calculada' => $duracionTiempo,
+                ];
+            }
+
+            $result[] = [
+                'carpeta' => $carpeta,
+                'tiempos' => $tiempos,
+                'duracion_total_calculada' => $totalDuracion,
+            ];
+        }
+
+        return $result;
+    }
+
+    public function agendaPorFecha(string $fecha): array
+    {
+        $date = $this->parseDate($fecha);
+        $target = $date->format('Y-m-d');
+
+        $agenda = array_values(array_filter(
+            $this->state['carpetas'],
+            fn ($carpeta) => $carpeta['fecha_emision'] === $target
+        ));
+
+        $detalle = [];
+        foreach ($agenda as $carpeta) {
+            $tiempos = array_values(array_filter(array_map(
+                fn ($tiempoId) => $this->state['tiempos'][$tiempoId] ?? null,
+                $carpeta['tiempo_ids']
+            )));
+            $detalle[] = [
+                'carpeta' => $carpeta,
+                'tiempos' => $tiempos,
+            ];
+        }
+
+        return $detalle;
+    }
+
+    private function parseDate(?string $value): DateTimeImmutable
+    {
+        if ($value === null || trim($value) === '') {
+            throw new InvalidArgumentException('La fecha de emisión es obligatoria.');
+        }
+
+        $date = DateTimeImmutable::createFromFormat('Y-m-d', substr(trim($value), 0, 10));
+        if (!$date) {
+            throw new InvalidArgumentException('Formato de fecha inválido, utilice YYYY-MM-DD.');
+        }
+
+        return $date;
+    }
+
+    private function validatePntIds(array $ids): void
+    {
+        foreach ($ids as $id) {
+            if (!isset($this->state['pnts'][$id])) {
+                throw new InvalidArgumentException("El PNT {$id} no existe.");
+            }
+        }
+    }
+
+    private function validateTiempoIds(array $ids): void
+    {
+        foreach ($ids as $id) {
+            if (!isset($this->state['tiempos'][$id])) {
+                throw new InvalidArgumentException("El tiempo {$id} no existe.");
+            }
+        }
+    }
+}

--- a/backend/lib/Storage.php
+++ b/backend/lib/Storage.php
@@ -1,0 +1,57 @@
+<?php
+
+class Storage
+{
+    private string $path;
+
+    public function __construct(string $path)
+    {
+        $this->path = $path;
+        $dir = dirname($this->path);
+        if (!is_dir($dir)) {
+            mkdir($dir, 0777, true);
+        }
+        if (!file_exists($this->path)) {
+            $this->save([
+                'pnts' => [],
+                'tiempos' => [],
+                'carpetas' => [],
+            ]);
+        }
+    }
+
+    public function load(): array
+    {
+        $raw = file_get_contents($this->path);
+        if ($raw === false || $raw === '') {
+            return [
+                'pnts' => [],
+                'tiempos' => [],
+                'carpetas' => [],
+            ];
+        }
+
+        $data = json_decode($raw, true);
+        if (!is_array($data)) {
+            throw new RuntimeException('No se pudo decodificar el archivo de datos.');
+        }
+
+        return array_merge(
+            ['pnts' => [], 'tiempos' => [], 'carpetas' => []],
+            $data
+        );
+    }
+
+    public function save(array $data): void
+    {
+        $encoded = json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+        if ($encoded === false) {
+            throw new RuntimeException('No se pudo serializar el estado.');
+        }
+
+        $result = file_put_contents($this->path, $encoded . PHP_EOL);
+        if ($result === false) {
+            throw new RuntimeException('No se pudo escribir el archivo de datos.');
+        }
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3.8'
+
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
+    container_name: futbolfolder-backend
+    ports:
+      - "8000:80"
+    volumes:
+      - backend-data:/var/www/html/data
+  frontend:
+    build:
+      context: .
+      dockerfile: frontend/Dockerfile
+    container_name: futbolfolder-frontend
+    ports:
+      - "3000:80"
+    depends_on:
+      - backend
+volumes:
+  backend-data:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,5 @@
+FROM nginx:alpine
+
+COPY frontend/ /usr/share/nginx/html/
+
+EXPOSE 80

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,615 @@
+const API_URL = (window.APP_CONFIG && window.APP_CONFIG.apiUrl) || 'http://localhost:8000/api';
+
+const initialForms = {
+  pnt: {
+    titulo: '',
+    guion: '',
+    duracion_segundos: 0,
+    formato: '',
+    marca: '',
+    notas: '',
+  },
+  tiempo: {
+    nombre: '',
+    duracion_total: 0,
+  },
+  carpeta: {
+    nombre: '',
+    fecha_emision: '',
+    observaciones: '',
+  },
+  asignacionPnt: {
+    tiempo_id: '',
+    pnt_id: '',
+  },
+  asignacionTiempo: {
+    carpeta_id: '',
+    tiempo_id: '',
+  },
+  agenda: {
+    date: '',
+  },
+};
+
+function useForms() {
+  const [forms, setForms] = React.useState(initialForms);
+
+  const update = React.useCallback((key, field, value) => {
+    setForms((prev) => ({
+      ...prev,
+      [key]: {
+        ...prev[key],
+        [field]: value,
+      },
+    }));
+  }, []);
+
+  const reset = React.useCallback((key) => {
+    setForms((prev) => ({
+      ...prev,
+      [key]: initialForms[key],
+    }));
+  }, []);
+
+  return { forms, update, reset };
+}
+
+function App() {
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState(null);
+  const [pnts, setPnts] = React.useState([]);
+  const [tiempos, setTiempos] = React.useState([]);
+  const [carpetas, setCarpetas] = React.useState([]);
+  const [resumen, setResumen] = React.useState([]);
+  const [agenda, setAgenda] = React.useState([]);
+  const { forms, update, reset } = useForms();
+
+  const fetchJson = React.useCallback(async (url, options = {}) => {
+    const response = await fetch(url, {
+      headers: {
+        'Content-Type': 'application/json',
+        ...(options.headers || {}),
+      },
+      ...options,
+    });
+
+    if (response.status === 204) {
+      return null;
+    }
+
+    const body = await response.json().catch(() => null);
+
+    if (!response.ok) {
+      const message = (body && body.error) || 'Error inesperado';
+      throw new Error(message);
+    }
+
+    return body;
+  }, []);
+
+  const refresh = React.useCallback(async () => {
+    try {
+      setLoading(true);
+      const [pntsData, tiemposData, carpetasData, resumenData] = await Promise.all([
+        fetchJson(`${API_URL}/pnts`),
+        fetchJson(`${API_URL}/tiempos`),
+        fetchJson(`${API_URL}/carpetas`),
+        fetchJson(`${API_URL}/report/resumen`),
+      ]);
+      setPnts(pntsData);
+      setTiempos(tiemposData);
+      setCarpetas(carpetasData);
+      setResumen(resumenData);
+      setError(null);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [fetchJson]);
+
+  React.useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const handleCreatePnt = async (event) => {
+    event.preventDefault();
+    try {
+      await fetchJson(`${API_URL}/pnts`, {
+        method: 'POST',
+        body: JSON.stringify(forms.pnt),
+      });
+      reset('pnt');
+      refresh();
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  const handleDeletePnt = async (identifier) => {
+    if (!window.confirm('¿Deseas eliminar el PNT seleccionado?')) return;
+    try {
+      await fetchJson(`${API_URL}/pnts/${identifier}`, {
+        method: 'DELETE',
+      });
+      refresh();
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  const handleCreateTiempo = async (event) => {
+    event.preventDefault();
+    try {
+      await fetchJson(`${API_URL}/tiempos`, {
+        method: 'POST',
+        body: JSON.stringify(forms.tiempo),
+      });
+      reset('tiempo');
+      refresh();
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  const handleDeleteTiempo = async (identifier) => {
+    if (!window.confirm('¿Eliminar tiempo y sus asociaciones?')) return;
+    try {
+      await fetchJson(`${API_URL}/tiempos/${identifier}`, {
+        method: 'DELETE',
+      });
+      refresh();
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  const handleCreateCarpeta = async (event) => {
+    event.preventDefault();
+    try {
+      await fetchJson(`${API_URL}/carpetas`, {
+        method: 'POST',
+        body: JSON.stringify(forms.carpeta),
+      });
+      reset('carpeta');
+      refresh();
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  const handleDeleteCarpeta = async (identifier) => {
+    if (!window.confirm('¿Eliminar carpeta programada?')) return;
+    try {
+      await fetchJson(`${API_URL}/carpetas/${identifier}`, {
+        method: 'DELETE',
+      });
+      refresh();
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  const handleAsignarPnt = async (event) => {
+    event.preventDefault();
+    if (!forms.asignacionPnt.tiempo_id || !forms.asignacionPnt.pnt_id) {
+      setError('Selecciona un tiempo y un PNT para la asignación.');
+      return;
+    }
+    try {
+      await fetchJson(`${API_URL}/tiempos/${forms.asignacionPnt.tiempo_id}/pnts`, {
+        method: 'POST',
+        body: JSON.stringify({ pnt_id: forms.asignacionPnt.pnt_id }),
+      });
+      reset('asignacionPnt');
+      refresh();
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  const handleAsignarTiempo = async (event) => {
+    event.preventDefault();
+    if (!forms.asignacionTiempo.carpeta_id || !forms.asignacionTiempo.tiempo_id) {
+      setError('Selecciona carpeta y tiempo para completar la asignación.');
+      return;
+    }
+    try {
+      await fetchJson(`${API_URL}/carpetas/${forms.asignacionTiempo.carpeta_id}/tiempos`, {
+        method: 'POST',
+        body: JSON.stringify({ tiempo_id: forms.asignacionTiempo.tiempo_id }),
+      });
+      reset('asignacionTiempo');
+      refresh();
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  const handleAgenda = async (event) => {
+    event.preventDefault();
+    try {
+      const resultado = await fetchJson(`${API_URL}/report/agenda?date=${forms.agenda.date}`);
+      setAgenda(resultado);
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  const totalDuracionPnt = (tiempo) => {
+    const pntDuracion = tiempo.pnt_ids
+      .map((id) => pnts.find((item) => item.identifier === id))
+      .filter(Boolean)
+      .reduce((acc, item) => acc + (item.duracion_segundos || 0), 0);
+    return (tiempo.duracion_total || 0) + pntDuracion;
+  };
+
+  return (
+    <main>
+      <h1>FutbolFolder CMS</h1>
+      {error && <div className="error">{error}</div>}
+
+      <section>
+        <header>
+          <h2>Nueva pieza PNT</h2>
+          <span>Registra la publicidad disponible</span>
+        </header>
+        <form onSubmit={handleCreatePnt}>
+          <label>
+            Título
+            <input
+              value={forms.pnt.titulo}
+              onChange={(event) => update('pnt', 'titulo', event.target.value)}
+              required
+            />
+          </label>
+          <label>
+            Formato
+            <input
+              value={forms.pnt.formato}
+              onChange={(event) => update('pnt', 'formato', event.target.value)}
+              placeholder="Spot, mención, PNT"
+            />
+          </label>
+          <label>
+            Marca
+            <input
+              value={forms.pnt.marca}
+              onChange={(event) => update('pnt', 'marca', event.target.value)}
+            />
+          </label>
+          <label>
+            Duración (segundos)
+            <input
+              type="number"
+              min="0"
+              value={forms.pnt.duracion_segundos}
+              onChange={(event) => update('pnt', 'duracion_segundos', Number(event.target.value))}
+            />
+          </label>
+          <label style={{ gridColumn: '1 / -1' }}>
+            Guion
+            <textarea
+              value={forms.pnt.guion}
+              onChange={(event) => update('pnt', 'guion', event.target.value)}
+              required
+            />
+          </label>
+          <label style={{ gridColumn: '1 / -1' }}>
+            Notas
+            <textarea
+              value={forms.pnt.notas}
+              onChange={(event) => update('pnt', 'notas', event.target.value)}
+            />
+          </label>
+          <button type="submit">Guardar PNT</button>
+        </form>
+
+        {loading ? (
+          <div className="empty-state">Cargando información…</div>
+        ) : pnts.length === 0 ? (
+          <div className="empty-state">Aún no se registraron PNTs.</div>
+        ) : (
+          <ul className="card-grid">
+            {pnts.map((pnt) => (
+              <li className="card" key={pnt.identifier}>
+                <h3>{pnt.titulo}</h3>
+                <span className="badge">{pnt.formato || 'Formato sin definir'}</span>
+                <small className="meta">Marca: {pnt.marca || 'N/D'}</small>
+                <p>{pnt.guion}</p>
+                {pnt.notas && <p><strong>Notas:</strong> {pnt.notas}</p>}
+                <small className="meta">Duración: {pnt.duracion_segundos} seg</small>
+                <button className="secondary" onClick={() => handleDeletePnt(pnt.identifier)}>
+                  Eliminar
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section>
+        <header>
+          <h2>Planificación de tiempos</h2>
+          <span>Organiza cortes y tandas</span>
+        </header>
+        <form onSubmit={handleCreateTiempo}>
+          <label>
+            Nombre del tiempo
+            <input
+              value={forms.tiempo.nombre}
+              onChange={(event) => update('tiempo', 'nombre', event.target.value)}
+              required
+            />
+          </label>
+          <label>
+            Duración base (segundos)
+            <input
+              type="number"
+              min="0"
+              value={forms.tiempo.duracion_total}
+              onChange={(event) => update('tiempo', 'duracion_total', Number(event.target.value))}
+            />
+          </label>
+          <button type="submit">Guardar tiempo</button>
+        </form>
+
+        <form onSubmit={handleAsignarPnt}>
+          <label>
+            Tiempo
+            <select
+              value={forms.asignacionPnt.tiempo_id}
+              onChange={(event) => update('asignacionPnt', 'tiempo_id', event.target.value)}
+              required
+            >
+              <option value="">Selecciona un tiempo</option>
+              {tiempos.map((tiempo) => (
+                <option key={tiempo.identifier} value={tiempo.identifier}>
+                  {tiempo.nombre}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label>
+            PNT
+            <select
+              value={forms.asignacionPnt.pnt_id}
+              onChange={(event) => update('asignacionPnt', 'pnt_id', event.target.value)}
+              required
+            >
+              <option value="">Selecciona un PNT</option>
+              {pnts.map((pnt) => (
+                <option key={pnt.identifier} value={pnt.identifier}>
+                  {pnt.titulo}
+                </option>
+              ))}
+            </select>
+          </label>
+          <button type="submit">Agregar PNT al tiempo</button>
+        </form>
+
+        {loading ? (
+          <div className="empty-state">Cargando planificación…</div>
+        ) : tiempos.length === 0 ? (
+          <div className="empty-state">Aún no se registraron tiempos.</div>
+        ) : (
+          <ul className="card-grid">
+            {tiempos.map((tiempo) => (
+              <li className="card" key={tiempo.identifier}>
+                <h3>{tiempo.nombre}</h3>
+                <small className="meta">Duración total estimada: {totalDuracionPnt(tiempo)} seg</small>
+                <div>
+                  <strong>PNTs asignados:</strong>
+                  {tiempo.pnt_ids.length === 0 ? (
+                    <div className="empty-state" style={{ padding: '0.75rem', marginTop: '0.75rem' }}>
+                      Sin asignaciones
+                    </div>
+                  ) : (
+                    <ul className="list-inline">
+                      {tiempo.pnt_ids.map((id) => {
+                        const pnt = pnts.find((item) => item.identifier === id);
+                        return <li key={id}>{pnt ? pnt.titulo : id}</li>;
+                      })}
+                    </ul>
+                  )}
+                </div>
+                <button className="secondary" onClick={() => handleDeleteTiempo(tiempo.identifier)}>
+                  Eliminar tiempo
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section>
+        <header>
+          <h2>Carpetas programadas</h2>
+          <span>Define qué sale al aire y cuándo</span>
+        </header>
+        <form onSubmit={handleCreateCarpeta}>
+          <label>
+            Nombre de carpeta
+            <input
+              value={forms.carpeta.nombre}
+              onChange={(event) => update('carpeta', 'nombre', event.target.value)}
+              required
+            />
+          </label>
+          <label>
+            Fecha de emisión
+            <input
+              type="date"
+              value={forms.carpeta.fecha_emision}
+              onChange={(event) => update('carpeta', 'fecha_emision', event.target.value)}
+              required
+            />
+          </label>
+          <label style={{ gridColumn: '1 / -1' }}>
+            Observaciones
+            <textarea
+              value={forms.carpeta.observaciones}
+              onChange={(event) => update('carpeta', 'observaciones', event.target.value)}
+            />
+          </label>
+          <button type="submit">Guardar carpeta</button>
+        </form>
+
+        <form onSubmit={handleAsignarTiempo}>
+          <label>
+            Carpeta
+            <select
+              value={forms.asignacionTiempo.carpeta_id}
+              onChange={(event) => update('asignacionTiempo', 'carpeta_id', event.target.value)}
+              required
+            >
+              <option value="">Selecciona una carpeta</option>
+              {carpetas.map((carpeta) => (
+                <option key={carpeta.identifier} value={carpeta.identifier}>
+                  {carpeta.nombre} ({carpeta.fecha_emision})
+                </option>
+              ))}
+            </select>
+          </label>
+          <label>
+            Tiempo
+            <select
+              value={forms.asignacionTiempo.tiempo_id}
+              onChange={(event) => update('asignacionTiempo', 'tiempo_id', event.target.value)}
+              required
+            >
+              <option value="">Selecciona un tiempo</option>
+              {tiempos.map((tiempo) => (
+                <option key={tiempo.identifier} value={tiempo.identifier}>
+                  {tiempo.nombre}
+                </option>
+              ))}
+            </select>
+          </label>
+          <button type="submit">Agregar tiempo a carpeta</button>
+        </form>
+
+        {loading ? (
+          <div className="empty-state">Sincronizando…</div>
+        ) : carpetas.length === 0 ? (
+          <div className="empty-state">Aún no se registraron carpetas.</div>
+        ) : (
+          <ul className="card-grid">
+            {carpetas.map((carpeta) => (
+              <li className="card" key={carpeta.identifier}>
+                <h3>{carpeta.nombre}</h3>
+                <small className="meta">Emite el {carpeta.fecha_emision}</small>
+                {carpeta.observaciones && <p>{carpeta.observaciones}</p>}
+                <div>
+                  <strong>Tiempos programados</strong>
+                  {carpeta.tiempo_ids.length === 0 ? (
+                    <div className="empty-state" style={{ padding: '0.75rem', marginTop: '0.75rem' }}>
+                      Ningún tiempo asignado
+                    </div>
+                  ) : (
+                    <ul className="list-inline">
+                      {carpeta.tiempo_ids.map((id) => {
+                        const tiempo = tiempos.find((item) => item.identifier === id);
+                        return <li key={id}>{tiempo ? tiempo.nombre : id}</li>;
+                      })}
+                    </ul>
+                  )}
+                </div>
+                <button className="secondary" onClick={() => handleDeleteCarpeta(carpeta.identifier)}>
+                  Eliminar carpeta
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section>
+        <header>
+          <h2>Agenda diaria</h2>
+          <span>Consulta por fecha</span>
+        </header>
+        <form onSubmit={handleAgenda}>
+          <label>
+            Fecha
+            <input
+              type="date"
+              value={forms.agenda.date}
+              onChange={(event) => update('agenda', 'date', event.target.value)}
+              required
+            />
+          </label>
+          <button type="submit">Generar agenda</button>
+        </form>
+        {agenda.length === 0 ? (
+          <div className="empty-state">Selecciona una fecha para ver su programación.</div>
+        ) : (
+          <ul className="card-grid">
+            {agenda.map((item) => (
+              <li className="card" key={item.carpeta.identifier}>
+                <h3>{item.carpeta.nombre}</h3>
+                <small className="meta">Emite el {item.carpeta.fecha_emision}</small>
+                <div>
+                  <strong>Tiempos</strong>
+                  {item.tiempos.filter(Boolean).length === 0 ? (
+                    <div className="empty-state" style={{ padding: '0.75rem', marginTop: '0.75rem' }}>
+                      Sin tiempos planificados
+                    </div>
+                  ) : (
+                    <ul className="list-inline">
+                      {item.tiempos.filter(Boolean).map((tiempo) => (
+                        <li key={tiempo.identifier}>{tiempo.nombre}</li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section>
+        <header>
+          <h2>Resumen general</h2>
+          <span>Totaliza duración y detalle</span>
+        </header>
+        {resumen.length === 0 ? (
+          <div className="empty-state">Todavía no hay datos para el resumen.</div>
+        ) : (
+          <ul className="card-grid">
+            {resumen.map((item) => (
+              <li className="card" key={item.carpeta.identifier}>
+                <h3>{item.carpeta.nombre}</h3>
+                <small className="meta">
+                  Fecha: {item.carpeta.fecha_emision} · Duración total calculada: {item.duracion_total_calculada} seg
+                </small>
+                {item.tiempos.map((detalle) => (
+                  <div key={detalle.tiempo.identifier}>
+                    <strong>{detalle.tiempo.nombre}</strong>
+                    <small className="meta"> · {detalle.duracion_total_calculada} seg</small>
+                    {detalle.pnts.length === 0 ? (
+                      <div className="empty-state" style={{ padding: '0.75rem', marginTop: '0.75rem' }}>
+                        Sin PNTs asignados
+                      </div>
+                    ) : (
+                      <ul className="list-inline">
+                        {detalle.pnts.map((pnt) => (
+                          <li key={pnt.identifier}>
+                            {pnt.titulo} ({pnt.duracion_segundos} seg)
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
+                ))}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </main>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>FutbolFolder CMS</title>
+    <link rel="stylesheet" href="style.css" />
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script crossorigin src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="text/babel" src="app.js"></script>
+  </body>
+</html>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,0 +1,207 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  background-color: #f5f6fa;
+  color: #1f1f1f;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+}
+
+main {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 4rem;
+}
+
+h1 {
+  text-align: center;
+  margin-bottom: 2rem;
+  font-size: 2.25rem;
+}
+
+section {
+  background: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.08);
+  margin-bottom: 2rem;
+  padding: 1.75rem;
+}
+
+section header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+section header h2 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+section header span {
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+form {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem 1.5rem;
+  margin-bottom: 1.25rem;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.85rem;
+  color: #475569;
+  font-weight: 600;
+  gap: 0.35rem;
+}
+
+input,
+textarea,
+select,
+button {
+  font-size: 1rem;
+  border-radius: 8px;
+  border: 1px solid #cbd5f5;
+  padding: 0.6rem 0.75rem;
+  font-family: inherit;
+  background-color: #f8fafc;
+  color: inherit;
+}
+
+textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+
+button {
+  cursor: pointer;
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  color: white;
+  border: none;
+  font-weight: 600;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 20px rgba(37, 99, 235, 0.25);
+}
+
+button.secondary {
+  background: transparent;
+  color: #1d4ed8;
+  border: 1px solid #2563eb;
+}
+
+ul.card-grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.card {
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 1rem;
+  background-color: #fdfdff;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.card h3 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.75rem;
+  padding: 0.2rem 0.6rem;
+  background: rgba(59, 130, 246, 0.15);
+  color: #1d4ed8;
+  border-radius: 999px;
+}
+
+small.meta {
+  color: #64748b;
+  font-size: 0.8rem;
+}
+
+.list-inline {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.list-inline li {
+  background: #e0f2fe;
+  color: #0369a1;
+  padding: 0.3rem 0.5rem;
+  border-radius: 8px;
+  font-size: 0.75rem;
+}
+
+.empty-state {
+  border: 2px dashed #cbd5f5;
+  border-radius: 10px;
+  padding: 1.5rem;
+  text-align: center;
+  color: #64748b;
+  font-style: italic;
+}
+
+.error {
+  background: rgba(248, 113, 113, 0.15);
+  color: #b91c1c;
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  border-radius: 10px;
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    background-color: #0f172a;
+    color: #f1f5f9;
+  }
+
+  section {
+    background: #111c37;
+    box-shadow: 0 10px 25px rgba(15, 23, 42, 0.3);
+  }
+
+  input,
+  textarea,
+  select,
+  button {
+    background-color: #1e293b;
+    border-color: #334155;
+  }
+
+  .card {
+    background-color: #1e293b;
+    border-color: #334155;
+  }
+
+  .list-inline li {
+    background: rgba(125, 211, 252, 0.2);
+    color: #bae6fd;
+  }
+}


### PR DESCRIPTION
## Summary
- reescribir la capa de backend como una API REST en PHP con persistencia JSON que cubre CRUD de PNTs, tiempos, carpetas y reportes
- crear un frontend React con formularios y tableros para operar el CMS y consumir la nueva API
- actualizar la documentación con la arquitectura PHP/React e ignorar el archivo de datos generado en tiempo de ejecución

## Testing
- php -l backend/index.php
- php -l backend/lib/CmsService.php
- php -l backend/lib/Storage.php

------
https://chatgpt.com/codex/tasks/task_e_68e329fad718832f8b3b68980ae9efcc